### PR TITLE
Support Deploying Translations

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -52,4 +52,6 @@ elif [ "$1" == "staging" ]; then
     copy-push 'ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/orchid.dev'
 elif [ "$1" == "production" ]; then
     copy-push 'ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/orchid.com'
+elif [ "${#1}" == "2" ]; then
+    copy-push "ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/${1}.orchid.com"
 fi


### PR DESCRIPTION
Add the ability to run `./deploy.sh ja` or `./deploy.sh zh` to deploy a translated version of the site. The infrastructure on the remote end must already exist to support the language being pushed. There is currently no error handling, so something like `./deploy.sh -h` might lead to unexpected surprises.