### PR TITLE
Fix typo on Network page

### DIFF
--- a/src/app/about-network/about-network.component.html
+++ b/src/app/about-network/about-network.component.html
@@ -24,7 +24,7 @@
 	</div>
 	<h2>Contributors</h2>
 	<ul>
-	  <li>Relay and bridge nodes stack Orchid tokens (ERC20) to earn fees for bandwidth.</li>
+	  <li>Relay and bridge nodes stake Orchid tokens (ERC20) to earn fees for bandwidth.</li>
 	  <li>The stake keeps contributors honest by serving as a decentralized reputation system.</li>
 	  <li>The list of nodes is stored in an Ethereum smart contract that is decentralized, accessible, and pen to participation</li>
 	</ul>


### PR DESCRIPTION
Nodes `stake` tokens, they don't `stack` them.