### PR TITLE
fix a broken link to a blog post on the OXT page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,7 @@ import { ContactComponent } from './contact/contact.component';
 import { AboutCompanyComponent } from './about-company/about-company.component';
 import { JoinComponent } from './join/join.component';
 import { OxtComponent } from './oxt/oxt.component';
-import { PartnersComponent } from './partners/partners.component';
+import //{ PartnersComponent } from './partners/partners.component';
 import { WhereOXTComponent } from './where-oxt/where-oxt.component';
 import { SetupVideoSectionComponent } from './setup-video-section/setup-video-section.component';
 import { VideoSectionComponent } from './video-section/video-section.component';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,7 +56,7 @@ import { MetaService } from './MetaService';
     AboutCompanyComponent,
     JoinComponent,
     OxtComponent,
-    PartnersComponent,
+    //PartnersComponent,
     NewsletterSignupPage,
     WhereOXTComponent,
     VideoSectionComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,7 @@ import { ContactComponent } from './contact/contact.component';
 import { AboutCompanyComponent } from './about-company/about-company.component';
 import { JoinComponent } from './join/join.component';
 import { OxtComponent } from './oxt/oxt.component';
-import //{ PartnersComponent } from './partners/partners.component';
+//import { PartnersComponent } from './partners/partners.component';
 import { WhereOXTComponent } from './where-oxt/where-oxt.component';
 import { SetupVideoSectionComponent } from './setup-video-section/setup-video-section.component';
 import { VideoSectionComponent } from './video-section/video-section.component';

--- a/src/app/oxt/oxt.component.html
+++ b/src/app/oxt/oxt.component.html
@@ -58,7 +58,7 @@
           would get approximately 250 GBs of service, which could last an entire year.
         </p>
         <p class="medium">
-          <a href="https://blog.orchid.dev/how-much-does-bandwidth-cost-on-orchid/" class="oxt-special-link">
+          <a href="https://blog.orchid.com/how-much-does-bandwidth-cost-on-orchid/" class="oxt-special-link">
             Read our blog on bandwidth pricing here
           </a>
         </p>

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,23 +1,23 @@
-import {Routes} from "@angular/router";
+import { Routes } from "@angular/router";
 
-import {AboutCompanyComponent} from "./about-company/about-company.component";
-import {AboutNetworkComponent} from "./about-network/about-network.component";
-import {HowItWorksComponent} from "./how-it-works/how-it-works.component";
-import {EventsComponent} from "./events/events.component";
-import {FaqComponent} from "./faq/faq.component";
-import {ContactComponent} from "./contact/contact.component";
-import {HomeComponent} from "./home/home.component";
-import {DownloadComponent} from "./download/download.component";
-import {PageLayoutComponent} from "./page-layout/page-layout.component";
+import { AboutCompanyComponent } from "./about-company/about-company.component";
+import { AboutNetworkComponent } from "./about-network/about-network.component";
+import { HowItWorksComponent } from "./how-it-works/how-it-works.component";
+import { EventsComponent } from "./events/events.component";
+import { FaqComponent } from "./faq/faq.component";
+import { ContactComponent } from "./contact/contact.component";
+import { HomeComponent } from "./home/home.component";
+import { DownloadComponent } from "./download/download.component";
+import { PageLayoutComponent } from "./page-layout/page-layout.component";
 import {
-    PrivacyPolicyComponent
+	PrivacyPolicyComponent
 } from "./privacy-policy/privacy-policy.component";
 import {
-    MobilePrivacyPolicyComponent
+	MobilePrivacyPolicyComponent
 } from "./mobile-privacy-policy/mobile-privacy-policy.component";
-import {ServiceTermsComponent} from "./service-terms/service-terms.component";
-import {VisionComponent} from "./vision/vision.component";
-import {NotFoundComponent} from "./not-found/not-found.component";
+import { ServiceTermsComponent } from "./service-terms/service-terms.component";
+import { VisionComponent } from "./vision/vision.component";
+import { NotFoundComponent } from "./not-found/not-found.component";
 import { JoinComponent } from './join/join.component';
 import { OxtComponent } from './oxt/oxt.component';
 import { PartnersComponent } from './partners/partners.component';
@@ -25,45 +25,45 @@ import { NewsletterSignupPage } from './newsletter-signup-page/newsletter-signup
 import { WebinarLPComponent } from './webinar-lp/webinar-lp.component';
 
 export const routes: Routes = [
-    {
-	path: "",
-	component: PageLayoutComponent,
-	children: [
-	    {path: "", component: HomeComponent},
-	    {path: "app", redirectTo: "download"},
-	    {path: "app.html", redirectTo: "download"},
-	    {path: "network", component: AboutNetworkComponent},
-	    {path: "network.html", redirectTo: "network"},
-	    {path: "how-it-works", component: HowItWorksComponent},
-	    {path: "how-it-works.html", redirectTo: "how-it-works"},
-	    {path: "vision", component: VisionComponent},
-	    {path: "vision.html", redirectTo: "vision"},
-	    {path: "about-us", component: AboutCompanyComponent},
-	    {path: "about-us.html", redirectTo: "about-us"},
-	    {path: "faq", component: FaqComponent},
-	    {path: "faq.html", redirectTo: "faq"},
-	    {path: "contact", component: ContactComponent},
-	    {path: "download", component: DownloadComponent},
-	    {path: "download.html", redirectTo: "download"},
-	    {path: "events", component: EventsComponent},
-      {path: "events.html", redirectTo: "events"},
-	    {path: "join", component: JoinComponent},
-      {path: "join.html", redirectTo: "join"},
-	    {path: "webinar", component: WebinarLPComponent},
-	    {path: "privacy-policy", component: PrivacyPolicyComponent},
-	    {path: "mobile-privacy-policy", component: MobilePrivacyPolicyComponent},
-	    {path: "privacy-policy.html", redirectTo: "privacy-policy"},
-	    {path: "mobile-privacy-policy.html", redirectTo: "mobile-privacy-policy"},
-	    {path: "service-terms", component: ServiceTermsComponent},
-      {path: "service-terms.html", redirectTo: "service-terms"},
-	    {path: "oxt", component: OxtComponent},
-		{path: "oxt.html", redirectTo: "oxt"},
-		{path: "partners", component: PartnersComponent},
-		{path: "partners.html", redirectTo: "partners"},
-		{path: "newsletter-signup", component: NewsletterSignupPage},
-		{path: "newsletter-signup.html", redirectTo: 'newsletter-signup'},
-      {path: "**", component: NotFoundComponent}
-	]
-    },
-    {path: "index.html", redirectTo: ""},
+	{
+		path: "",
+		component: PageLayoutComponent,
+		children: [
+			{ path: "", component: HomeComponent },
+			{ path: "app", redirectTo: "download" },
+			{ path: "app.html", redirectTo: "download" },
+			{ path: "network", component: AboutNetworkComponent },
+			{ path: "network.html", redirectTo: "network" },
+			{ path: "how-it-works", component: HowItWorksComponent },
+			{ path: "how-it-works.html", redirectTo: "how-it-works" },
+			{ path: "vision", component: VisionComponent },
+			{ path: "vision.html", redirectTo: "vision" },
+			{ path: "about-us", component: AboutCompanyComponent },
+			{ path: "about-us.html", redirectTo: "about-us" },
+			{ path: "faq", component: FaqComponent },
+			{ path: "faq.html", redirectTo: "faq" },
+			{ path: "contact", component: ContactComponent },
+			{ path: "download", component: DownloadComponent },
+			{ path: "download.html", redirectTo: "download" },
+			{ path: "events", component: EventsComponent },
+			{ path: "events.html", redirectTo: "events" },
+			{ path: "join", component: JoinComponent },
+			{ path: "join.html", redirectTo: "join" },
+			{ path: "webinar", component: WebinarLPComponent },
+			{ path: "privacy-policy", component: PrivacyPolicyComponent },
+			{ path: "mobile-privacy-policy", component: MobilePrivacyPolicyComponent },
+			{ path: "privacy-policy.html", redirectTo: "privacy-policy" },
+			{ path: "mobile-privacy-policy.html", redirectTo: "mobile-privacy-policy" },
+			{ path: "service-terms", component: ServiceTermsComponent },
+			{ path: "service-terms.html", redirectTo: "service-terms" },
+			{ path: "oxt", component: OxtComponent },
+			{ path: "oxt.html", redirectTo: "oxt" },
+			{ path: "partners", component: PartnersComponent },
+			{ path: "partners.html", redirectTo: "partners" },
+			{ path: "newsletter-signup", component: NewsletterSignupPage },
+			{ path: "newsletter-signup.html", redirectTo: 'newsletter-signup' },
+			{ path: "**", component: NotFoundComponent }
+		]
+	},
+	{ path: "index.html", redirectTo: "" },
 ];

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -20,7 +20,7 @@ import { VisionComponent } from "./vision/vision.component";
 import { NotFoundComponent } from "./not-found/not-found.component";
 import { JoinComponent } from './join/join.component';
 import { OxtComponent } from './oxt/oxt.component';
-import { PartnersComponent } from './partners/partners.component';
+//import { PartnersComponent } from './partners/partners.component';
 import { NewsletterSignupPage } from './newsletter-signup-page/newsletter-signup-page.component';
 import { WebinarLPComponent } from './webinar-lp/webinar-lp.component';
 
@@ -58,7 +58,7 @@ export const routes: Routes = [
 			{ path: "service-terms.html", redirectTo: "service-terms" },
 			{ path: "oxt", component: OxtComponent },
 			{ path: "oxt.html", redirectTo: "oxt" },
-			{ path: "partners", component: PartnersComponent },
+//			{ path: "partners", component: PartnersComponent },
 			{ path: "partners.html", redirectTo: "partners" },
 			{ path: "newsletter-signup", component: NewsletterSignupPage },
 			{ path: "newsletter-signup.html", redirectTo: 'newsletter-signup' },

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -58,8 +58,8 @@ export const routes: Routes = [
       {path: "service-terms.html", redirectTo: "service-terms"},
 	    {path: "oxt", component: OxtComponent},
 		{path: "oxt.html", redirectTo: "oxt"},
-		//{path: "partners", component: PartnersComponent},
-		//{path: "partners.html", redirectTo: "partners"},
+		{path: "partners", component: PartnersComponent},
+		{path: "partners.html", redirectTo: "partners"},
 		{path: "newsletter-signup", component: NewsletterSignupPage},
 		{path: "newsletter-signup.html", redirectTo: 'newsletter-signup'},
       {path: "**", component: NotFoundComponent}


### PR DESCRIPTION
This also adds and then removes again the routes for the partner's page, I might be able to force push to avoid these slightly messier pull requests in the future, but until then this is caused by only having a single staging environment, and it isn't that much of an issue to begin with.

The custom 404 checker is also still in development but has been neglected for some time, I'll make sure to re-prioritize that.