### PR TITLE
Add fallback for mailto links, stack guest names on mobile

### DIFF
--- a/src/app/podcast-ep34/podcast.component.html
+++ b/src/app/podcast-ep34/podcast.component.html
@@ -34,7 +34,7 @@
                                         Spotify
                                     </div>
                                 </a>
-                                <a class="podcast-button" href="">
+                                <a class="podcast-button" href="https://www.stitcher.com/show/follow-the-white-rabbit/episode/data-privacy-and-the-social-media-echo-chamber-with-joe-toscano-81347507">
                                     <img src="/assets/img/podcast/platforms/stitcher.svg" alt="stitcher">
                                     <div class="podcast-button__text">
                                         Stitcher
@@ -46,7 +46,7 @@
                                         Castbox
                                     </div>
                                 </a>
-                                <a class="podcast-button" href="">
+                                <a class="podcast-button" href="https://www.deezer.com/us/episode/276129032">
                                     <img src="/assets/img/podcast/platforms/deezer.svg" alt="deezer">
                                     <div class="podcast-button__text">
                                         Deezer

--- a/src/app/podcast-ep34/podcast.component.html
+++ b/src/app/podcast-ep34/podcast.component.html
@@ -58,7 +58,7 @@
                                         Podbean
                                     </div>
                                 </a>
-                                <a class="podcast-button" href="">
+                                <a class="podcast-button" href="https://tunein.com/podcasts/Technology-Podcasts/Follow-the-White-Rabbit-p1330281/?topicId=160555305">
                                     <img src="/assets/img/podcast/platforms/tunein.svg" alt="tunein">
                                     <div class="podcast-button__text">
                                         Tunein

--- a/src/app/podcast/podcast.component.html
+++ b/src/app/podcast/podcast.component.html
@@ -37,7 +37,7 @@
                                         Spotify
                                     </div>
                                 </a>
-                                <a class="podcast-button" href="">
+                                <a class="podcast-button" href="https://www.stitcher.com/show/follow-the-white-rabbit/episode/data-privacy-and-the-social-media-echo-chamber-with-joe-toscano-81347507">
                                     <img src="/assets/img/podcast/platforms/stitcher.svg" alt="stitcher">
                                     <div class="podcast-button__text">
                                         Stitcher
@@ -49,7 +49,7 @@
                                         Castbox
                                     </div>
                                 </a>
-                                <a class="podcast-button" href="">
+                                <a class="podcast-button" href="https://www.deezer.com/us/episode/276129032">
                                     <img src="/assets/img/podcast/platforms/deezer.svg" alt="deezer">
                                     <div class="podcast-button__text">
                                         Deezer

--- a/src/app/podcast/podcast.component.html
+++ b/src/app/podcast/podcast.component.html
@@ -61,7 +61,7 @@
                                         Podbean
                                     </div>
                                 </a>
-                                <a class="podcast-button" href="">
+                                <a class="podcast-button" href="https://tunein.com/podcasts/Technology-Podcasts/Follow-the-White-Rabbit-p1330281/?topicId=160555305">
                                     <img src="/assets/img/podcast/platforms/tunein.svg" alt="tunein">
                                     <div class="podcast-button__text">
                                         Tunein

--- a/src/app/priv8/priv8.component.html
+++ b/src/app/priv8/priv8.component.html
@@ -480,7 +480,18 @@
     <h3 class="priv8__heading">PARTICIPATE</h3>
     <h3 class="priv8__subheading">Want to contribute?</h3>
     <br />
-    <a href="mailto:amanda@orchid.com"><button class="btn-secondary">Let us know!</button></a>
+    <div class="participate__special">
+        <a href="mailto:amanda@orchid.com" (click)="onParticipateClick()">
+            <button class="btn-secondary">Let us know!</button>
+        </a>
+        <div class="participate__email-wrap" [class.expanded]="this.expandParticipate">
+            <div class="participate__email-container">
+                <div class="participate__email">
+                    amanda@orchid.com
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <!--<div class="partners__wrapper">

--- a/src/app/priv8/priv8.component.html
+++ b/src/app/priv8/priv8.component.html
@@ -32,21 +32,27 @@
                     <source srcset="/assets/img/priv8/edward_snowden-big.webp" type="image/webp">
                     <img src="/assets/img/priv8/edward_snowden-big.png" width="400" height="400">
                 </picture>
-                EDWARD SNOWDEN
+                EDWARD
+                <br />
+                SNOWDEN
             </div>
             <div class="hero__featuring-item">
                 <picture>
                     <source srcset="/assets/img/priv8/audrey_tang-big.webp" type="image/webp">
                     <img src="/assets/img/priv8/audrey_tang-big.png" width="400" height="400">
                 </picture>
-                AUDREY TANG
+                AUDREY
+                <br />
+                TANG
             </div>
             <div class="hero__featuring-item">
                 <picture>
                     <source srcset="/assets/img/priv8/zooko_wilcox-big.webp" type="image/webp">
                     <img src="/assets/img/priv8/zooko_wilcox-big.png" width="400" height="400">
                 </picture>
-                ZOOKO WILCOX
+                ZOOKO
+                <br />
+                WILCOX
             </div>
         </div>
     </div>

--- a/src/app/priv8/priv8.component.scss
+++ b/src/app/priv8/priv8.component.scss
@@ -470,6 +470,7 @@ h4.priv8__heading {
 }
 .participate__email-container {
 	position: absolute;
+	z-index: 10;
 	top: 0;
 	width: 100%;
 	text-align: center;
@@ -485,6 +486,9 @@ h4.priv8__heading {
 	display: inline-block;
 	font-size: 1rem;
 	margin-top: 1rem;
+	@include mobile {
+		margin-top: 0.5rem;
+	}
 	//border: 3px solid $orc-purple;
 	border-bottom: solid 3px #5f45ba;
 }

--- a/src/app/priv8/priv8.component.scss
+++ b/src/app/priv8/priv8.component.scss
@@ -55,7 +55,7 @@ h4.priv8__heading {
 }
 
 .hero__container {
-	padding: 6rem 0 5rem;
+	padding: 6rem 0 4.5rem;
 	@media (max-width: 765px) {
 		padding-top: 1rem;
 	}
@@ -452,6 +452,33 @@ h4.priv8__heading {
 		top: 100px;
 		background-image: url(/assets/img/priv8/participate-pattern-1.svg);
 	}
+}
+.participate__email-wrap {
+	width: 100%;
+	text-align: center;
+	margin-top: 0;
+	height: 0px;
+	position: relative;
+}
+.participate__email-container {
+	position: absolute;
+	top: 0;
+	width: 100%;
+	text-align: center;
+	overflow: hidden;
+	height: 0rem;
+	transition: height 1s ease;
+}
+.participate__email-wrap.expanded > .participate__email-container {
+	height: 4rem;
+}
+
+.participate__email {
+	display: inline-block;
+	font-size: 1rem;
+	margin-top: 1rem;
+	//border: 3px solid $orc-purple;
+	border-bottom: solid 3px #5f45ba;
 }
 
 .agenda__wrapper {

--- a/src/app/priv8/priv8.component.scss
+++ b/src/app/priv8/priv8.component.scss
@@ -181,6 +181,14 @@ h4.priv8__heading {
 			margin-top: -7rem;
 		}
 	}
+	@include not-mobile {
+		br {
+			display: none;
+		}
+	}
+	@include mobile {
+		line-height: 1.25;
+	}
 }
 
 .hero__vector-wrapper {

--- a/src/app/priv8/priv8.component.ts
+++ b/src/app/priv8/priv8.component.ts
@@ -8,9 +8,14 @@ import { MetaService } from '../MetaService';
 })
 export class Priv8 implements OnInit {
     year: number;
+    expandParticipate: boolean = false;
 
     constructor(private meta: MetaService) {
         this.year = new Date().getFullYear();
+    }
+
+    onParticipateClick() {
+        this.expandParticipate = !this.expandParticipate;
     }
 
     ngOnInit() {


### PR DESCRIPTION
Priv8: Adds a fallback for when `mailto:example@example.com` email links don't work, displays the email in plaintext for the "participate" section.

Priv8: Stacks all guest names in the hero section on mobile.

Adds remaining podcast platform links to episode 34