### PR TITLE
Implement app store UTM passing

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,7 +41,7 @@ export class AppComponent implements OnInit {
 
     let location = document.location._href ? document.location._href : document.location.pathname;
     if (!location.match(/\/$/)) {
-        location += '/';
+      location += '/';
     }
     if (!location.match(/\*/)) {
       if (this.localeId !== 'en-US') {
@@ -75,21 +75,25 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    if (window.location.search && window.location.search.length > 0 && window.location.search.match(/(utm_source|utm_medium|utm_campaign|utm_term|utm_content)/i)) {
-      localStorage.queryParams = window.location.search;
-      localStorage.queryParamsDate = Date.now();
+    if (typeof window !== "undefined" && typeof localStorage !== "undefined") {
+      if (window.location.search && window.location.search.length > 0 && window.location.search.match(/(utm_source|utm_medium|utm_campaign|utm_term|utm_content)/i)) {
+        localStorage.queryParams = window.location.search;
+        localStorage.queryParamsDate = Date.now();
+      } else if (localStorage.queryParamsDate) {
+        
+      }
+      if (localStorage.queryParams) {
+        window['landingQueryParams'] = localStorage.queryParams;
+      }
+
+      this.router.events.subscribe((evt) => {
+        if (!(evt instanceof NavigationEnd)) return;
+
+        // Scroll the user to the top of the page on load/refresh?
+        // const win = typeof window !== "undefined" && window;
+        // if (win) win.scrollTo(0, 0);
+
+      }, (err) => { }, () => { });
     }
-    if (localStorage.queryParams) {
-      window['landingQueryParams'] = localStorage.queryParams;
-    }
-
-    this.router.events.subscribe((evt) => {
-      if (!(evt instanceof NavigationEnd)) return;
-
-      // Scroll the user to the top of the page on load/refresh?
-      // const win = typeof window !== "undefined" && window;
-      // if (win) win.scrollTo(0, 0);
-
-    }, (err) => { }, () => { });
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -80,7 +80,11 @@ export class AppComponent implements OnInit {
         localStorage.queryParams = window.location.search;
         localStorage.queryParamsDate = Date.now();
       } else if (localStorage.queryParamsDate) {
-        
+        const oneDay = 1000*60*60*24;
+        if (Number(localStorage.queryParamsDate) < Date.now() - oneDay*30) {
+          localStorage.removeItem('queryParamsDate');
+          localStorage.removeItem('queryParams');
+        } // Delete UTM parameters after 30 days
       }
       if (localStorage.queryParams) {
         window['landingQueryParams'] = localStorage.queryParams;

--- a/src/app/page-layout/page-layout.component.ts
+++ b/src/app/page-layout/page-layout.component.ts
@@ -164,6 +164,7 @@ export class PageLayoutComponent implements OnInit {
       doc.addEventListener("scroll", checkShadow);
       window.addEventListener("resize", checkShadow);
 
+      if (typeof window !== "undefined" && window['landingQueryParams']) {
       if (window['landingQueryParams']) {
         const appstore_links = doc.querySelectorAll('a[href^="https://apps.apple.com"], a[href^="https://play.google.com"]');
         for (let index = 0; index < appstore_links.length; index++) {

--- a/src/app/page-layout/page-layout.component.ts
+++ b/src/app/page-layout/page-layout.component.ts
@@ -165,12 +165,19 @@ export class PageLayoutComponent implements OnInit {
       window.addEventListener("resize", checkShadow);
 
       if (typeof window !== "undefined" && window['landingQueryParams']) {
-      if (window['landingQueryParams']) {
-        const appstore_links = doc.querySelectorAll('a[href^="https://apps.apple.com"], a[href^="https://play.google.com"]');
+        const appstore_links = doc.querySelectorAll('a[href^="https://apps.apple.com"]');
         for (let index = 0; index < appstore_links.length; index++) {
           const element = appstore_links[index];
           let url = element.getAttribute('href');
           url = url.split('?')[0] + window['landingQueryParams'];
+          element.setAttribute('href', url);
+        }
+
+        const googleplay_links = doc.querySelectorAll('a[href^="https://play.google.com"]');
+        for (let index = 0; index < googleplay_links.length; index++) {
+          const element = googleplay_links[index];
+          let url = element.getAttribute('href');
+          url = url.split('&')[0] + window['landingQueryParams'].replace('?', '&');
           element.setAttribute('href', url);
         }
       }


### PR DESCRIPTION
Caches UTM parameters using the `localStorage` API, and passes them to app store links.

- Only works on JavaScript enabled browsers
- You MUST include a trailing slash in the URL, otherwise the server will redirect the user without the parameters
- Any new UTM parameters will over-write currently cached ones
- Cached UTM parameters will be cleared automatically after 30 days.