### PR TITLE
Fix Discord link

### DIFF
--- a/extractedTranslations/en/common.json
+++ b/extractedTranslations/en/common.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.",
   "Pay only for what you actually use": "Pay only for what you actually use",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Podcast",
   "Preferred Providers": "Preferred Providers",
   "Preferred Providers | Orchid": "Preferred Providers | Orchid",

--- a/pendingTranslations/fr/other/new-not-imported.json
+++ b/pendingTranslations/fr/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/hi/other/new-not-imported.json
+++ b/pendingTranslations/hi/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/id/other/new-not-imported.json
+++ b/pendingTranslations/id/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/it/other/new-not-imported.json
+++ b/pendingTranslations/it/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/ja/other/new-not-imported.json
+++ b/pendingTranslations/ja/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/ko/other/new-not-imported.json
+++ b/pendingTranslations/ko/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/pt/other/new-not-imported.json
+++ b/pendingTranslations/pt/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/ptbr/other/new-not-imported.json
+++ b/pendingTranslations/ptbr/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/ru/other/new-not-imported.json
+++ b/pendingTranslations/ru/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/tr/other/new-not-imported.json
+++ b/pendingTranslations/tr/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/ua/other/new-not-imported.json
+++ b/pendingTranslations/ua/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/pendingTranslations/zh/other/new-not-imported.json
+++ b/pendingTranslations/zh/other/new-not-imported.json
@@ -7,7 +7,7 @@
     "Let's reclaim the Internet together! We are looking for partnership opportunities with infrastructure providers and integration partners that want to build with Orchid. Contact us and we'll get back to you shortly.": "Повертаймо вільне користування Інтернетом! Ми шукаємо можливості партнерства з постачальниками інфраструктури та партнерами з інтеграції, які хочуть розвивати свої потужності разом з Orchid. Звертайтеся до нас, і ми швидко вам відповімо.",
     "Mailing Address": "Поштова адреса",
     "We want to hear from you": "Нам важлива ваша думка",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/src/components/common/FooterSocialIcons.js
+++ b/src/components/common/FooterSocialIcons.js
@@ -22,7 +22,7 @@ const FooterSocialIcons = (props) => {
 			</a>
 		</li>
 		<li className='list-none inline-block m-1'>
-			<a href="https://discord.gg/GDbxmjxX9F" target="_blank" rel="noopener noreferrer" aria-label="Join us on Discord" title="Discord">
+			<a href="https://discord.gg/invite/GDbxmjxX9F" target="_blank" rel="noopener noreferrer" aria-label="Join us on Discord" title="Discord">
 				<img src={URLBase.replace('{icon}', "discord")} style={{ width: "32px", height: "auto" }} alt="Discord" width="32" height="32" />
 			</a>
 		</li>

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "Tu correo electrónico",
     "Your Name": "Tu nombre",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "¿Necesitas ayuda con un producto?",
     "Orchid Office Address": "Dirección de las oficinas de Orchid",
     "Other inquiries": "Otras preguntas",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Toma nota: si estás buscando soporte técnico de Orchid, por favor visita <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Toma nota: si estás buscando soporte técnico de Orchid, por favor visita <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Siempre estamos buscando oportunidades colaborativas con proveedores de infraestructura y socios de integración que deseen unirse a Orchid. Si ese eres tú, o si tienes otras preguntas generales, por favor llena el formulario a continuación o escríbenos a <1>contact@orchid.com</1> y nos pondremos en contacto contigo pronto.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Ponte en contacto"

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -393,7 +393,7 @@
     "Your Email": "Votre e-mail",
     "Your Name": "Votre nom",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -432,7 +432,7 @@
     "Need product support?": "Besoin d'une assistance produit ?",
     "Orchid Office Address": "Adresse des bureaux Orchid",
     "Other inquiries": "Autres demandes",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Remarque : si vous demandez de l'aide à l'assistance Orchid, rendez-vous sur <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Remarque : si vous demandez de l'aide à l'assistance Orchid, rendez-vous sur <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Nous sommes toujours à la recherche d'opportunités de collaboration avec des fournisseurs d'infrastructures et des partenaires d'intégration qui souhaitent se développer avec Orchid. Si c'est vous, ou si vous avez d'autres questions d'ordre général, veuillez remplir le formulaire ci-dessous ou nous contacter sur <1>contact@orchid.com</1> et nous vous répondrons dans les plus brefs délais.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Contactez-nous"

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "आपका ईमेल",
     "Your Name": "आपका नाम",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "उत्पाद को लेकर कोई मदद चाहिए?",
     "Orchid Office Address": "ऑर्किड कार्यालय का पता",
     "Other inquiries": "अन्य पूछताछ",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "कृपया ध्यान में रखें: यदि आप ऑर्किड समर्थन से मदद चाहते हैं, तो कृपया <1>discord.gg/GDbxmjxX9F</1> में पधारें",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "कृपया ध्यान में रखें: यदि आप ऑर्किड समर्थन से मदद चाहते हैं, तो कृपया <1>discord.gg/invite/GDbxmjxX9F</1> में पधारें",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "हमें सदा ही ऐसे अधिसंरचना प्रदाताओं और समेकन साझेदारों के साथ सहयोगात्मक अवसरों की तलाश रहती है, जो ऑर्किड के साथ निर्माण करना चाहते हैं। यदि यह आप हैं, या आपकी कोई समान्य पूछताछ है, तो कृपया नीचे दिए गए फॉर्म को भरें या <1>contact@orchid.com</1> पर हमें लिखें, और हम शीघ्र ही आपसे संपर्क करेंगे।",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "हमें मिलें"

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "Email Anda",
     "Your Name": "Nama Anda",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "Butuh dukungan produk?",
     "Orchid Office Address": "Alamat kantor Orchid",
     "Other inquiries": "Pertanyaan lain",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Catatan: Jika Anda mencari bantuan dari Dukungan Orchid, silakan kunjungi <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Catatan: Jika Anda mencari bantuan dari Dukungan Orchid, silakan kunjungi <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Kami selalu mencari peluang kolaborasi dengan penyedia infrastruktur dan mitra pengintegrasian yang ingin mengembangkan sesuatu dengan Orchid. Jika itu Anda, atau jika Anda memiliki pertanyaan umum lainnya, silakan isi formulir di bawah ini atau kirim pesan ke <1>contact@orchid.com</1>—kami akan segera menghubungi Anda kembali.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Hubungi kami"

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "Il tuo indirizzo email",
     "Your Name": "Il tuo nome",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "Hai bisogno di supporto per il prodotto?",
     "Orchid Office Address": "Indirizzo della sede di Orchid",
     "Other inquiries": "Altre richieste",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Nota: se vuoi contattare il supporto di Orchid, visita <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Nota: se vuoi contattare il supporto di Orchid, visita <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Siamo sempre alla ricerca di opportunità collaborative con fornitori di infrastrutture e partner di integrazione che desiderano collaborare con Orchid. Se questo è il tuo caso o se hai altre domande generali, compila il modulo sottostante oppure contattaci all'indirizzo <1>contact@orchid.com</1>: ti risponderemo a breve.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Contattaci"

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "メールアドレス",
     "Your Name": "お名前",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "製品サポートが必要ですか？",
     "Orchid Office Address": "Orchid オフィス アドレス",
     "Other inquiries": "その他のお問い合わせ",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "ご注意：Orchid サポートをご希望の場合は、<1>discord.gg/GDbxmjxX9F</1> 宛にお問い合わせください。",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "ご注意：Orchid サポートをご希望の場合は、<1>discord.gg/invite/GDbxmjxX9F</1> 宛にお問い合わせください。",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "私どもは、Orchid を利用した構築をお考えのインフラストラクチャ プロバイダーや統合パートナーの皆様とのパートナーシップの機会を求めております。ご関心がおありの場合、またはその他の一般的なご質問がおありの場合は、以下のフォームに記入するか、<1> contact@orchid.com</1> にお問い合わせいただければ、すぐにご連絡いたします。",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "連絡する"

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "이메일",
     "Your Name": "이름",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "제품 관련 지원이 필요하세요?",
     "Orchid Office Address": "Orchid 사무실 주소",
     "Other inquiries": "기타 문의 사항",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "주의: Orchid 지원팀의 도움이 필요하시면 <1>discord.gg/GDbxmjxX9F</1>을 방문하시기 바랍니다",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "주의: Orchid 지원팀의 도움이 필요하시면 <1>discord.gg/invite/GDbxmjxX9F</1>을 방문하시기 바랍니다",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "저희는 Orchid와 함께 일하고 싶은 인프라 공급업체 및 통합 파트너와 협력할 수 있는 기회를 항상 모색하고 있습니다. 귀하께서 이에 해당하시거나, 다른 문의 사항이 있으실 경우, 아래 양식을 작성하시거나 <1>contact@orchid.com</1>으로 연락해 주시기 바랍니다. 신속하게 답변해 드리겠습니다.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "연락하기"

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "Email",
     "Your Name": "Nome",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "Precisa de apoio sobre o produto?",
     "Orchid Office Address": "Morada dos Escritórios Orchid",
     "Other inquiries": "Outras questões",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Note: se estiver à procura de ajuda do Apoio Técnico do Orchid, visite <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Note: se estiver à procura de ajuda do Apoio Técnico do Orchid, visite <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Estamos sempre à procura de oportunidades de colaboração com prestadores de infraestruturas e parceiros de integração que queiram criar com o Orchid. Se for o seu caso ou se tiver quaisquer outras questões gerais, preencha o formulário abaixo ou entre em contacto através de <1>contact@orchid.com</1> e responderemos brevemente.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Entre em contacto"

--- a/src/locales/ptbr/translation.json
+++ b/src/locales/ptbr/translation.json
@@ -371,7 +371,7 @@
     "Your Email": "Seu e-mail",
     "Your Name": "Seu nome",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -410,7 +410,7 @@
     "Need product support?": "Precisa de suporte de produto?",
     "Orchid Office Address": "Endereço dos escritórios da Orchid",
     "Other inquiries": "Outras dúvidas",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Observação: Caso esteja procurando ajuda do Suporte da Orchid, acesse <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Observação: Caso esteja procurando ajuda do Suporte da Orchid, acesse <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Estamos sempre em busca de oportunidades de colaboração com provedores de infraestrutura e parceiros de integração que queiram criar com a Orchid. Se for você um deles, ou se tiver outras dúvidas gerais, preencha o formulário abaixo ou entre em contato pelo e-mail <1>contact@orchid.com</1>, que responderemos rapidamente.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Entre em contato"

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "Ваш адрес эл. почты",
     "Your Name": "Ваше имя",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "Нужна помощь по работе с продуктом?",
     "Orchid Office Address": "Адрес офиса Orchid",
     "Other inquiries": "Другие запросы",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Обратите внимание: если вам нужна помощь службы поддержки Orchid, перейдите на сайт <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Обратите внимание: если вам нужна помощь службы поддержки Orchid, перейдите на сайт <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Мы всегда рады сотрудничеству с поставщиками инфраструктуры и партнерами по интеграции, которые готовы развиваться в одном направлении с Orchid. Если это про вас или у вас есть другие запросы общего характера, заполните форму ниже или напишите нам по адресу <1>contact@orchid.com</1>. Мы с вами свяжемся в кратчайшие сроки.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Связаться"

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "E-posta Adresiniz",
     "Your Name": "Adınız",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "Ürün desteğine mi ihtiyacınız var?",
     "Orchid Office Address": "Orchid Ofis Adresi",
     "Other inquiries": "Diğer konular",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Lütfen unutmayın: Orchid Desteğinden yardım istiyorsanız lütfen <1>discord.gg/GDbxmjxX9F</1> adresini ziyaret edin",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Lütfen unutmayın: Orchid Desteğinden yardım istiyorsanız lütfen <1>discord.gg/invite/GDbxmjxX9F</1> adresini ziyaret edin",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Orchid ile geliştirme yapmak isteyen altyapı sağlayıcıları ve entegrasyon partnerleriyle iş birliği fırsatlarını her zaman bekliyoruz. Eğer aradığımız kişi sizseniz ya da diğer genel konularda sorularınız varsa lütfen aşağıdaki formu doldurun ya da bizimle <1>contact@orchid.com</1> adresinden iletişim kurun, size kısa süre içinde dönelim.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Bize ulaşın"

--- a/src/locales/ua/translation.json
+++ b/src/locales/ua/translation.json
@@ -368,7 +368,7 @@
     "Your Name": "Ваше імʼя",
     "Your message has been sent": "Повідомлення надіслано",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -410,7 +410,7 @@
     "Need product support?": "¿Necesitas ayuda con un producto?",
     "Orchid Office Address": "Dirección de las oficinas de Orchid",
     "Other inquiries": "Otras preguntas",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Toma nota: si estás buscando soporte técnico de Orchid, por favor visita <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Toma nota: si estás buscando soporte técnico de Orchid, por favor visita <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "Siempre estamos buscando oportunidades colaborativas con proveedores de infraestructura y socios de integración que deseen unirse a Orchid. Si ese eres tú, o si tienes otras preguntas generales, por favor llena el formulario a continuación o escríbenos a <1>contact@orchid.com</1> y nos pondremos en contacto contigo pronto.",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "Ponte en contacto"

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -392,7 +392,7 @@
     "Your Email": "您的电子邮箱",
     "Your Name": "您的姓名",
     "https://blog.orchid.com/": "https://blog.orchid.com/",
-    "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+    "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
     "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
     "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
     "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",
@@ -431,7 +431,7 @@
     "Need product support?": "需要产品支持？",
     "Orchid Office Address": "Orchid 办公地址",
     "Other inquiries": "其他咨询",
-    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "请注意：如果您正在寻求 Orchid 支持，请访问 <1>discord.gg/GDbxmjxX9F</1>",
+    "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "请注意：如果您正在寻求 Orchid 支持，请访问 <1>discord.gg/invite/GDbxmjxX9F</1>",
     "We are always looking for collaborative opportunities with infrastructure providers and integration partners that want to build with Orchid. If that’s you, or if you have any other general inquiries, please fill out the form below or get in touch at <1>contact@orchid.com</1> and we’ll get back to you shortly.": "我们始终期待能有机会展开多方合作，特别是想要与 Orchid 共同发展的基础架构提供商和集成合作伙伴。如果您也有此愿望，或您想要咨询任何其他一般问题，请填写下方表单或通过 <1>contact@orchid.com</1> 与我们联系，我们将尽快给您答复。",
     "We’d love to hear from you.": "We’d love to hear from you.",
     "Reach out": "欢迎联系"

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -72,7 +72,7 @@ function Page(props) {
 						</p>
 						<h5 className='mt-auto text-white text-lg mt-6'>
 							<Trans>
-								<a href="https://discord.gg/GDbxmjxX9F">DISCORD</a> or <a href="https://www.t.me/OrchidOfficial">TELEGRAM</a>
+								<a href="https://discord.gg/invite/GDbxmjxX9F">DISCORD</a> or <a href="https://www.t.me/OrchidOfficial">TELEGRAM</a>
 							</Trans>
 						</h5>
 					</Container>
@@ -88,7 +88,7 @@ function Page(props) {
 						</p>
 						<h5 className='mt-auto text-white text-lg mt-6'>
 							<Trans>
-								<a href="https://discord.gg/GDbxmjxX9F/">ORCHID DISCORD SERVER</a>
+								<a href="https://discord.gg/invite/GDbxmjxX9F/">ORCHID DISCORD SERVER</a>
 							</Trans>
 						</h5>
 					</Container>
@@ -106,7 +106,7 @@ function Page(props) {
 						<br />
 						<b>
 							<Trans>
-								Please note: If you are seeking help from Orchid Support, please visit <a href="https://discord.gg/GDbxmjxX9F/">discord.gg/GDbxmjxX9F</a>
+								Please note: If you are seeking help from Orchid Support, please visit <a href="https://discord.gg/invite/GDbxmjxX9F/">discord.gg/invite/GDbxmjxX9F</a>
 							</Trans>
 						</b>
 					</div>

--- a/translationImport/common_es.json
+++ b/translationImport/common_es.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Paga el servicio VPN con una de nuestras criptomonedas admitidas. ¿No eres un experto en criptomonedas? Puedes comprar una cuenta precargada directamente en la app.",
   "Pay only for what you actually use": "Paga solo por lo que realmente usas",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Observa los detalles de las conexiones de tu dispositivo utilizando el analizador de protocolo de red integrado con tecnología Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Toma nota: si estás buscando soporte técnico de Orchid, por favor visita <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Toma nota: si estás buscando soporte técnico de Orchid, por favor visita <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Podcast",
   "Preferred Providers": "Proveedores preferidos",
   "Preferred Providers | Orchid": "Proveedores preferidos | Orchid",

--- a/translationImport/common_fr.json
+++ b/translationImport/common_fr.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Payez pour le service VPN en utilisant l'une de nos cryptomonnaies prises en charge. Vous n'êtes pas expert en crypto ? Vous pouvez acheter un compte préchargé directement dans l'application.",
   "Pay only for what you actually use": "Ne payez que ce que vous utilisez réellement",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Regardez les détails des connexions de votre appareil en utilisant l'analyseur de protocole réseau intégré optimisé par Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Remarque : si vous demandez de l'aide à l'assistance Orchid, rendez-vous sur <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Remarque : si vous demandez de l'aide à l'assistance Orchid, rendez-vous sur <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Podcast",
   "Preferred Providers": "Fournisseurs privilégiés",
   "Preferred Providers | Orchid": "Fournisseurs privilégiés | Orchid",

--- a/translationImport/common_hi.json
+++ b/translationImport/common_hi.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "हमारे द्वारा समर्थित क्रिप्टो-मुद्राओं में से किसी एक का उपयोग करके वीपीएन सेवा के लिए भुगतान करें। क्रिप्टो से ज्यादा परिचित नहीं हैं? आप ऐप में ही एक पहले से क्रिप्टो-पोषित खाता खरीद सकते हैं।",
   "Pay only for what you actually use": "केवल उसी के लिए भुगतान करें जिसका आप वास्तव में उपयोग करते हैं",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "वायरशार्क द्वारा संचालित अंतःस्थापित नेटवर्क प्रोटोकॉल विश्लेषक का उपयोग करके अपने डिवाइस के कनेकश्नों के ब्योरे देखें।",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "कृपया ध्यान में रखें: यदि आप ऑर्किड समर्थन से मदद चाहते हैं, तो कृपया <1>discord.gg/GDbxmjxX9F</1> में पधारें",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "कृपया ध्यान में रखें: यदि आप ऑर्किड समर्थन से मदद चाहते हैं, तो कृपया <1>discord.gg/invite/GDbxmjxX9F</1> में पधारें",
   "Podcast": "पोडकास्ट",
   "Preferred Providers": "अनन्य रूप से जुड़ते हैं",
   "Preferred Providers | Orchid": "पसंदीदा प्रदाता | Orchid",

--- a/translationImport/common_id.json
+++ b/translationImport/common_id.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Bayar untuk layanan VPN menggunakan salah satu mata uang kripto yang kami dukung. Tidak paham mata uang kripto? Anda dapat membeli akun yang diisi lebih dahulu langsung dari aplikasi.",
   "Pay only for what you actually use": "Bayar hanya untuk apa yang benar-benar Anda gunakan",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Intip detail koneksi perangkat Anda dengan memanfaatkan penganalisis protokol jaringan bawaan yang didukung oleh Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Catatan: Jika Anda mencari bantuan dari Dukungan Orchid, silakan kunjungi <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Catatan: Jika Anda mencari bantuan dari Dukungan Orchid, silakan kunjungi <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Podcast",
   "Preferred Providers": "Penyedia pilihan",
   "Preferred Providers | Orchid": "Penyedia pilihan | Orchid",

--- a/translationImport/common_it.json
+++ b/translationImport/common_it.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Paga il servizio VPN utilizzando una delle nostre criptovalute supportate. Non sai granché di criptovalute? Puoi acquistare un account precaricato direttamente nell'app.",
   "Pay only for what you actually use": "Paghi solo per quello che usi effettivamente",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Scruta i dettagli delle connessioni del tuo dispositivo utilizzando l'analizzatore del protocollo di rete integrato basato su tecnologia Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Nota: se vuoi contattare il supporto di Orchid, visita <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Nota: se vuoi contattare il supporto di Orchid, visita <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Podcast",
   "Preferred Providers": "Provider preferiti",
   "Preferred Providers | Orchid": "Provider preferiti | Orchid",

--- a/translationImport/common_ja.json
+++ b/translationImport/common_ja.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "サポートされている暗号通貨の 1 つを使用して VPN サービスの料金を支払います。暗号に精通していませんか？アプリでプリロードされたアカウントを購入できます。",
   "Pay only for what you actually use": "実際に使用したものに対してのみ支払う",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Wireshark を搭載した組み込みのネットワーク プロトコル アナライザーを利用して、デバイスの接続の詳細を確認してください。",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "ご注意：Orchid サポートをご希望の場合は、<1>discord.gg/GDbxmjxX9F</1> 宛にお問い合わせください。",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "ご注意：Orchid サポートをご希望の場合は、<1>discord.gg/invite/GDbxmjxX9F</1> 宛にお問い合わせください。",
   "Podcast": "ポッドキャスト",
   "Preferred Providers": "優先プロバイダー",
   "Preferred Providers | Orchid": "優先プロバイダー  | Orchid",

--- a/translationImport/common_ko.json
+++ b/translationImport/common_ko.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "지원되는 암호화폐 중 하나를 사용하여 VPN 서비스 비용을 결제하세요. 암호화폐에 익숙하지 않습니까? 앱에서 직접 선불 계정을 구입할 수 있습니다.",
   "Pay only for what you actually use": "실제로 사용한 만큼만 지불합니다",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Wireshark에서 제공하는 내장 네트워크 프로토콜 분석기를 활용하여 기기 연결의 세부 사항을 살펴보세요.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "주의: Orchid 지원팀의 도움이 필요하시면 <1>discord.gg/GDbxmjxX9F</1>을 방문하시기 바랍니다",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "주의: Orchid 지원팀의 도움이 필요하시면 <1>discord.gg/invite/GDbxmjxX9F</1>을 방문하시기 바랍니다",
   "Podcast": "팟캐스트",
   "Preferred Providers": "우선 제공업체",
   "Preferred Providers | Orchid": "우선 제공업체 | Orchid",

--- a/translationImport/common_pt.json
+++ b/translationImport/common_pt.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Pague pelo serviço de VPN com uma das nossas criptomoedas suportadas. Não tem experiência em criptomoedas? Pode adquirir uma conta pré-carregada a partir da aplicação.",
   "Pay only for what you actually use": "Pague apenas pelo que realmente utilizar",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Analise os detalhes das ligações do seu dispositivo ao utilizar o analisador incorporado de protocolo de rede fornecido pelo Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Note: se estiver à procura de ajuda do Apoio Técnico do Orchid, visite <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Note: se estiver à procura de ajuda do Apoio Técnico do Orchid, visite <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Podcast",
   "Preferred Providers": "Fornecedores Preferidos",
   "Preferred Providers | Orchid": "Fornecedores Preferidos | Orchid",

--- a/translationImport/common_pt_BR.json
+++ b/translationImport/common_pt_BR.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Pague pelo serviço de VPN usando uma das criptomoedas compatíveis. Não tem experiência com cripto? Você pode comprar uma conta pré-carregada no próprio aplicativo.",
   "Pay only for what you actually use": "Pague somente pelo que realmente usar",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Mergulhe nos detalhes das conexões do seu dispositivo usando o analisador de protocolo de rede integrado desenvolvido pela Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Observação: Caso esteja procurando ajuda do Suporte da Orchid, acesse <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Observação: Caso esteja procurando ajuda do Suporte da Orchid, acesse <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Podcast",
   "Preferred Providers": "Provedores preferenciais",
   "Preferred Providers | Orchid": "Provedores preferenciais | Orchid",

--- a/translationImport/common_ru.json
+++ b/translationImport/common_ru.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Оплачивайте VPN с помощью одной из поддерживаемых криптовалют. Не разбираетесь в криптовалюте? Вы можете купить уже пополненный аккаунт прямо через приложение.",
   "Pay only for what you actually use": "Оплачивайте только по факту использования",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Изучите сведения о подключениях вашего устройства с помощью встроенного анализатора сетевых протоколов на базе Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Обратите внимание: если вам нужна помощь службы поддержки Orchid, перейдите на сайт <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Обратите внимание: если вам нужна помощь службы поддержки Orchid, перейдите на сайт <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Подкаст",
   "Preferred Providers": "Избранные провайдеры",
   "Preferred Providers | Orchid": "Избранные провайдеры | Orchid",

--- a/translationImport/common_tr.json
+++ b/translationImport/common_tr.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Desteklediğimiz kripto para birimlerinden biriyle VPN hizmeti için ödeme yapın. Kripto dünyasına aşina değil misiniz? Uygulama içinden önceden yüklenmiş bir hesap satın alabilirsiniz.",
   "Pay only for what you actually use": "Sadece gerçekten kullandığınız kadar ödeyin",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Wireshark tarafından desteklenen yerleşik ağ protokolü çözümleyicisini kullanarak cihazınızın bağlantı ayrıntılarını inceleyin.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Lütfen unutmayın: Orchid Desteğinden yardım istiyorsanız lütfen <1>discord.gg/GDbxmjxX9F</1> adresini ziyaret edin",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Lütfen unutmayın: Orchid Desteğinden yardım istiyorsanız lütfen <1>discord.gg/invite/GDbxmjxX9F</1> adresini ziyaret edin",
   "Podcast": "Podcast",
   "Preferred Providers": "Tercih Edilen Sağlayıcılar",
   "Preferred Providers | Orchid": "Tercih Edilen Sağlayıcılar | Orchid",

--- a/translationImport/common_ua.json
+++ b/translationImport/common_ua.json
@@ -368,7 +368,7 @@
   "Your Name": "Ваше імʼя",
   "Your message has been sent": "Повідомлення надіслано",
   "https://blog.orchid.com/": "https://blog.orchid.com/",
-  "https://discord.gg/GDbxmjxX9F": "https://discord.gg/GDbxmjxX9F",
+  "https://discord.gg/invite/GDbxmjxX9F": "https://discord.gg/invite/GDbxmjxX9F",
   "https://twitter.com/OrchidProtocol": "https://twitter.com/OrchidProtocol",
   "https://www.facebook.com/OrchidProtocol": "https://www.facebook.com/OrchidProtocol",
   "https://www.t.me/OrchidOfficial": "https://www.t.me/OrchidOfficial",

--- a/translationImport/common_uk.json
+++ b/translationImport/common_uk.json
@@ -258,7 +258,7 @@
   "Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "Оплатіть послугу VPN за допомогою однієї з підтримуваних криптовалют. Не розумієтеся в криптовалюті? Можна придбати попередньо поповнений рахунок прямо в додатку.",
   "Pay only for what you actually use": "Платіть лише за фактом користування",
   "Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "Переглядайте докладні дані з’єднань свого пристрою за допомогою вбудованого аналізу мережевих протоколів на платформі Wireshark.",
-  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "Увага! Якщо вам потрібна допомога служби підтримки Orchid, відвідайте <1>discord.gg/GDbxmjxX9F</1>",
+  "Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "Увага! Якщо вам потрібна допомога служби підтримки Orchid, відвідайте <1>discord.gg/invite/GDbxmjxX9F</1>",
   "Podcast": "Подкаст",
   "Preferred Providers": "Рекомендовані провайдери",
   "Preferred Providers | Orchid": "Рекомендовані провайдери | Orchid",

--- a/translationImport/common_zh.json
+++ b/translationImport/common_zh.json
@@ -258,7 +258,7 @@
 	"Pay for VPN service using one of our supported cryptocurrencies. Not crypto savvy? You can purchase a pre-loaded account right in the app.": "使用我们支持的其中一种加密货币支付 VPN 服务费用。不熟悉加密货币？您可以直接在应用中购买预充值帐户。",
 	"Pay only for what you actually use": "仅需为您的实际用量付费",
 	"Peer into the details of your device’s connections by utilizing the built-in network protocol analyzer powered by Wireshark.": "利用由 Wireshark 提供支持的内置网络协议分析器，查看设备连接的详细信息。",
-	"Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/GDbxmjxX9F</1>": "请注意：如果您正在寻求 Orchid 支持，请访问 <1>discord.gg/GDbxmjxX9F</1>",
+	"Please note: If you are seeking help from Orchid Support, please visit <1>discord.gg/invite/GDbxmjxX9F</1>": "请注意：如果您正在寻求 Orchid 支持，请访问 <1>discord.gg/invite/GDbxmjxX9F</1>",
 	"Podcast": "播客",
 	"Preferred Providers": "首选提供商",
 	"Preferred Providers | Orchid": "首选提供商 | Orchid",


### PR DESCRIPTION
Missing /invite in Discord link

Ran a find and replace to replace discord.gg/GDbxmjxX9F with discord.gg/invite/GDbxmjxX9F

Also tested link in browser to make sure it would work correctly before creating pull request; sorry for the inconvenience.
